### PR TITLE
Fixing random_step function

### DIFF
--- a/utils/model.py
+++ b/utils/model.py
@@ -40,7 +40,7 @@ def random_step(t,_pc_trainer, var=2.):
     optimizer = _pc_trainer.get_optimizer_x()
     # optimizer.zero_grad()
     for x in xs:
-        x.grad.normal_(0.,np.sqrt(var/optimizer.defaults['lr']))
+        x.grad.normal_(0.,np.sqrt(var * optimizer.defaults['lr']))
     optimizer.step()
 
 


### PR DESCRIPTION
In the calculation of the noise scaling, there was a mixup of division and multiplication. According to Algorithm 1 in the paper, it should be multiply Euler step and variance instead of division.